### PR TITLE
Add next fields to editor

### DIFF
--- a/editor/app/views/form.html
+++ b/editor/app/views/form.html
@@ -39,6 +39,7 @@
           "value": form.heading
         }) }}
       {% endif %}
+
       {% if form.phase %}
         {{ frontend.govukInput({
           "label": {

--- a/editor/app/views/page.html
+++ b/editor/app/views/page.html
@@ -57,6 +57,7 @@
         {% endif %}
 
         {% for field in page.fields %}
+
           {% set fieldindex = loop.index %}
 
           {# Wrap in a fieldset if multiple properties #}
@@ -66,6 +67,7 @@
               Field {{ fieldindex }}
             </legend>
           {% endif %}
+
           {% if field.label %}
             {{ frontend.govukInput({
               "label": {
@@ -85,6 +87,7 @@
               "value": field.legend
             }) }}
           {% endif %}
+
           {% if field.hint %}
             {{ frontend.govukInput({
               "label": {
@@ -95,16 +98,19 @@
               "value": field.hint
             }) }}
           {% endif %}
+
           {% if field.items %}
             {% for item in field.items %}
               {% set optionindex = loop.index %}
 
+              {# Wrap in a fieldset if multiple properties #}
               {% if item.hint %}
               <fieldset>
                 <legend class="visuallyhidden">
                   Field {{ fieldindex }}, option {{ optionindex }}
                 </legend>
               {% endif %}
+
               {% if item.label %}
                 {{ frontend.govukInput({
                   "label": {
@@ -115,6 +121,7 @@
                   "value": item.label
                 }) }}
               {% endif %}
+
               {% if item.hint %}
                 {{ frontend.govukInput({
                   "label": {
@@ -125,15 +132,21 @@
                   "value": item.hint
                 }) }}
               {% endif %}
-            {% endfor %}
+
+            {% endfor %} {# end of loop through items #}
+
             {% if item.hint %}
             </fieldset>
             {% endif %}
+
           {% endif %}
+
+          {# Wrap in a fieldset if multiple properties #}
           {% if field.hint %}
           </fieldset>
           {% endif %}
-        {% endfor %}
+
+        {% endfor %} {# end of loop through fields #}
 
         {{ frontend.govukButton({ "text": "Update", "classes": [] }) }}
       </form>

--- a/editor/app/views/page.html
+++ b/editor/app/views/page.html
@@ -148,6 +148,53 @@
 
         {% endfor %} {# end of loop through fields #}
 
+        {% if page.next | length > 1 %}
+        <fieldset>
+          <legend class="heading-small">
+            Next pages
+          </legend>
+          {% for option in page.next %}
+
+          <fieldset>
+            <legend>
+              Option {{ loop.index }}
+            </legend>
+            
+						{{ frontend.govukInput({
+							"label": {
+								"text": "Slug"
+							},
+							"name": option.id + ".page",
+							"id": option.id + ".page",
+							"value": page.next[loop.index0].page
+						}) }}
+
+						{{ frontend.govukInput({
+							"label": {
+								"text": "Condition"
+							},
+							"name": option.id + ".if",
+							"id": option.id + ".if",
+							"value": page.next[loop.index0].if
+						}) }}
+          </fieldset>
+
+          {% endfor %} {# end of loop through next page options #}
+
+         </fieldset>
+        {% else %}
+
+          {{ frontend.govukInput({
+            "label": {
+              "text": "Slug for next page"
+            },
+            "name": page.next[0].id + ".page",
+            "id": page.next[0].id + ".page",
+            "value": page.next[0].page
+          }) }}
+
+        {% endif %}
+
         {{ frontend.govukButton({ "text": "Update", "classes": [] }) }}
       </form>
     </div>


### PR DESCRIPTION
Adds fields to editor for next pages in the flow and the conditionals attached to each one.

The `next` property in the JSON data can be either a string or an array. I refactored the page models to ensure a consistent way of accessing it in the templates. In the templates it will always be an array of options, like `page.next[0].page` to access the page slug.