### PR TITLE
Extend linter

### DIFF
--- a/bin/lint.py
+++ b/bin/lint.py
@@ -8,6 +8,17 @@ class FormGraph:
     graph = {}
 
     def load(self, path):
+        """
+            Graph of all possible journeys through the data
+            
+            This graph is a Dictionary with each pair following the form:
+
+            {
+                <String> page key in form.pages : <List> list of <String> page key in form.pages
+            }
+
+            The value list contains keys to all pages listed in form.pages[page].next
+        """
         self.form = json.load(open(path))
         self.graph = {}
         for page in self.form['pages']:
@@ -19,7 +30,7 @@ class FormGraph:
             self.graph[page] = [n['page'] for n in p.get('next', [])]
 
     def cyclic(self):
-        """ test for cycles """
+        """ Tests all paths for any containing multiple references to a single page """
         self.cycle = []
         path = set()
         visited = set()
@@ -39,7 +50,14 @@ class FormGraph:
         return any(visit(v) for v in self.graph)
 
     def paths(self, path=['index'], paths=[]):
-        """ find paths from a point """
+        """
+            List of unique paths through the data, each following the format:
+
+            [
+                [<String> page key in form.pages, <String> page key in form.pages, ...]
+            ]
+            
+        """
         node = path[-1]
         if not self.graph[node]:
             return paths + [path]
@@ -49,6 +67,14 @@ class FormGraph:
         return paths
 
     def links(self):
+        """
+            Dictionary of connections between pages containing entries following the form:
+            
+            <String> page key in form.pages + "," + page key in form.pages: <Integer> number of
+                                                                            times this connection
+                                                                            appears in individual
+                                                                            journeys
+        """
         links = {}
         paths = graph.paths()
         for path in paths:

--- a/bin/lint.py
+++ b/bin/lint.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 
+import os
 import sys
 import json
+import argparse
 from pprint import pprint
 
 class FormGraph:
@@ -86,8 +88,18 @@ class FormGraph:
                 s = vertex
         return links
 
+parser = argparse.ArgumentParser(description='Lint the data for a form.')
+parser.add_argument('datafile', metavar='F', help='JSON file containing the data')
+args = parser.parse_args()
+print(args)
+
+datafile = args.datafile
+if (not os.path.isfile(datafile)):
+    print("{} does not exist".format(datafile), file=sys.stderr)
+    exit(1)
+
 graph = FormGraph()
-graph.load('examples/apply-for-a-medal.json')
+graph.load('{}'.format(args.datafile))
 
 if (graph.cyclic()):
     print("Cycle detected:", graph.cycle, file=sys.stderr)

--- a/bin/lint.py
+++ b/bin/lint.py
@@ -90,8 +90,9 @@ class FormGraph:
 
 parser = argparse.ArgumentParser(description='Lint the data for a form.')
 parser.add_argument('datafile', metavar='F', help='JSON file containing the data')
+parser.add_argument('--output', type=str, default='lint', help='Type of output',
+                    choices=['lint', 'paths', 'links'])
 args = parser.parse_args()
-print(args)
 
 datafile = args.datafile
 if (not os.path.isfile(datafile)):
@@ -101,13 +102,14 @@ if (not os.path.isfile(datafile)):
 graph = FormGraph()
 graph.load('{}'.format(args.datafile))
 
-if (graph.cyclic()):
-    print("Cycle detected:", graph.cycle, file=sys.stderr)
-    exit(1)
+output = args.output
+if (output == 'lint'):
+    if (graph.cyclic()):
+        print("Cycle detected:", graph.cycle, file=sys.stderr)
+        exit(1)
 
-paths = graph.paths()
-for path in paths:
-    print(path)
+if (output == 'paths'):
+    print(json.dumps(graph.paths(), indent=4), file=sys.stdout)
 
-#pprint(paths)
-#json.dump(paths, sys.stdout)
+if (output == 'links'):
+    print(json.dumps(graph.links(), indent=4), file=sys.stdout)


### PR DESCRIPTION
Let the linter operate on different JSON data files and give different formats of output.

The outputs were already in the code, this just extends the CLI to have them as options.