### PR TITLE
Add Select boxes fieldtype

### DIFF
--- a/examples/simple.json
+++ b/examples/simple.json
@@ -37,6 +37,12 @@
       "pagetype": "question",
       "heading": "Are you aged 18 or older?",
       "fields": ["adult"],
+      "next": "country"
+    },
+    "country": {
+      "pagetype": "question",
+      "heading": "What country are you applying from?",
+      "fields": ["country"],
       "next": "confirmation"
     },
     "confirmation": {
@@ -59,6 +65,21 @@
       "items": [
         { "label": "Yes", "value": "yes" },
         { "label": "No", "value": "no" }
+      ]
+    },
+    "country": {
+      "label": "Country",
+      "inputtype": "select",
+      "items": [
+        { "label": "Afghanistan", "value": "AF" },
+        { "label": "Albania", "value": "AL" },
+        { "label": "Algeria", "value": "DZ" },
+        { "label": "American Samoa", "value": "AS" },
+        { "label": "Andorra", "value": "AD" },
+        { "label": "Angola", "value": "AO" },
+        { "label": "Anguilla", "value": "AI" },
+        { "label": "Antigua and Barbuda", "value": "AG" },
+        { "label": "Argentina", "value": "AR" }
       ]
     }
   }

--- a/templates/frontend_macros.ntk
+++ b/templates/frontend_macros.ntk
@@ -94,6 +94,19 @@
 </div>
 {% endmacro %}
 
+
+{% macro govukSelectboxes(params={}) %}
+<div class="form-group">
+  <label class="form-label" for="{{ params.name }}">{{ params.label }}</label>
+  <select class="form-control" id="{{ params.id }}" name="{{ params.name }}">
+{% for item in params.items %}
+    <option value={{ item.value }}>{{ item.text }}</option>
+{% endfor %}
+  </select>
+</div>
+{% endmacro %}
+
+
 {% macro govukTextarea(params={}) %}
 <div class="form-group">
   {% if params.label %}<label class="form-label" for="{{ params.name }}">{{ params.label.text }}</label>{% endif %}

--- a/templates/submit_macros.ntk
+++ b/templates/submit_macros.ntk
@@ -147,6 +147,20 @@
     ]
 {{ frontend_endmacro() }}
 
+{%- elif field.inputtype == 'select' -%}
+  {{ frontend_macro('govukSelectboxes') }}
+    "id": {{ text_param(field.field) }},
+    "name": {{ text_param(field.field) }},
+    "label": {{ text_param(field.label) }},
+    "items" : [{% set comma = joiner() -%}
+    {% for item in field.items -%}
+      {{ comma() }}
+      { {%- if item.fieldref %}"fieldref": {{ text_param(item.fieldref) }}, "fieldhtml": {{ item.fieldref }}Ref, {% endif -%}
+        "text": {{ text_param(item.label) }}, "value": {{ text_param(item.value) }} }
+    {%- endfor %}
+    ]
+{{ frontend_endmacro() }}
+
 {%- elif field.inputtype == 'textarea' -%}
   {{ frontend_macro('govukTextarea') }}
     "name": {{ text_param(field.field) }},


### PR DESCRIPTION
We can now use select boxes with the following

```json
  "fields": {
    "country": {
      "label": "Country",
      "inputtype": "select",
      "items": [
        { "label": "Afghanistan", "value": "AF" },
        { "label": "Albania", "value": "AL" },
        { "label": "Algeria", "value": "DZ" },
        { "label": "American Samoa", "value": "AS" },
        { "label": "Andorra", "value": "AD" },

      ]
    }
  }
}
```