### PR TITLE
Allow nested fieldsets in editor and fix them in runner

### DIFF
--- a/bin/submit.js
+++ b/bin/submit.js
@@ -12,6 +12,7 @@ var chalk = require('chalk')
 var glob = require("glob")
 var yargs = require('yargs')
 var jsonfile = require('jsonfile')
+var utils = require('../lib/utils.js')
 
 
 var app_paths = [
@@ -118,6 +119,7 @@ function renderForm(form) {
 function loadForm(path) {
   console.log(chalk.blue('Loading ' + path))
   var form = JSON.parse(fs.readFileSync(path, 'utf8'))
+  var fieldrefLogs = {};
 
   // add field key to field object
   for (fieldref in form.fields) {
@@ -160,8 +162,15 @@ function loadForm(path) {
       }
     }
 
-    // TBD: calculate page fieldrefs
+    // log references to fields in page
+    if ('fieldrefs' in page) {
+      fieldrefLogs[name] = utils.logFieldrefs(page, name, form);
+    }
+
   }
+
+  // add unique variants of existing fields used multiple times
+  utils.makeFieldrefsUnique(fieldrefLogs, form);
 
   return form
 }

--- a/editor/app/assets/sass/editor.scss
+++ b/editor/app/assets/sass/editor.scss
@@ -52,3 +52,13 @@
   opacity: 0;
   transition: visibility 0s 1s, opacity 1s linear;
 }
+
+/* GOVUK Elements overrides */
+
+.column-one-half .form-control-2-3 {
+  width: 66.66%;
+}
+
+.column-one-half .column-one-half .form-control-2-3 {
+  width: 100%;
+}

--- a/editor/app/models.js
+++ b/editor/app/models.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const utils = require('../../lib/utils.js');
 
 
 class Datapoint {
@@ -269,6 +270,10 @@ class Page extends FormComponent {
   get id() { return `pages[${this.page}]`; }
 
   get url() { return `/forms/${this.form.name}/pages/${this.page}`; }
+
+  get uniqueFieldrefs() {
+    return utils.pruneFieldrefs(this._data, this.page, this.form._data);
+  }
 
   // Methods
 

--- a/editor/app/models.js
+++ b/editor/app/models.js
@@ -260,6 +260,10 @@ class Page extends FormComponent {
     return this._fields || [];
   }
 
+  get fieldrefs() {
+    return this._fieldrefs;
+  }
+
   get next() { return this._next; }
 
   get id() { return `pages[${this.page}]`; }
@@ -334,10 +338,6 @@ class Form {
 
   get fields() {
     return this._fields;
-  }
-
-  get fieldrefs() {
-    return this._fieldrefs;
   }
 
   get organisations() {

--- a/editor/app/models.js
+++ b/editor/app/models.js
@@ -76,8 +76,9 @@ const _getDatapoint = function(namespace, root) {
 
 
 class Field {
-  constructor(data) {
+  constructor(data, form) {
     this._data = data;
+    this.form = form;
 
     if ('items' in this._data) {
       this._items = this._data.items.map((item, idx) => {
@@ -139,6 +140,7 @@ class FieldItem {
 class Fieldset {
   constructor(data, form) {
     this._data = data;
+    this.form = form;
 
     this._fields = this._data.fields.map(name => {
       return form.createField(name)
@@ -210,7 +212,13 @@ class Page extends FormComponent {
     if ('fields' in this._data) {
       this._fields = this._data.fields.map(fieldName => {
         return form.fields[fieldName];
-      })
+      });
+    }
+
+    if ('fieldrefs' in this._data) {
+      this._fieldrefs = this._data.fieldrefs.map(fieldref => {
+        return form.fields[fieldref];
+      });
     }
 
     if ('next' in this._data) {
@@ -328,6 +336,10 @@ class Form {
     return this._fields;
   }
 
+  get fieldrefs() {
+    return this._fieldrefs;
+  }
+
   get organisations() {
     let form = this;
 
@@ -362,7 +374,7 @@ class Form {
     if ('fields' in fieldData) {
       result = new Fieldset(fieldData, this);
     } else {
-      result = new Field(fieldData);
+      result = new Field(fieldData, this);
     }
 
     result.name = name;

--- a/editor/app/routes/get.js
+++ b/editor/app/routes/get.js
@@ -32,15 +32,16 @@ const gets = {
 		});
 
 		router.get('/forms/:formname/pages/:pagename', function (req, res) {
-			let page = formsData.getForm(req.params.formname).page(req.params.pagename);
-			// if index page, rewrite prototype URL to remove page name
-			let pageName = (page.page == 'index') ? '' : page.page;
+      let form = formsData.getForm(req.params.formname);
+      let page = form.page(req.params.pagename);
+      // if index page, rewrite prototype URL to remove page name
+      let pageName = (page.page == 'index') ? '' : page.page;
 
 			res.render('page', {
 				'page': page,
-				'formname': req.params.formname,
+        'form': form,
 				'message': req.query.message,
-				'currentFormPage': `${req.params.formname}/${pageName}`
+				'currentFormPage': `${form.name}/${pageName}`
 			})
 		});
 

--- a/editor/app/routes/graphs.js
+++ b/editor/app/routes/graphs.js
@@ -8,7 +8,7 @@ const graphs = {
     // load graph data
     graphData.init();
 
-    router.get('/railroad', function (req, res) {
+    router.get('/:formname/railroad', function (req, res) {
       let onSuccess = function (data) {
         let graph = data.graph;
         let links = data.links;
@@ -34,7 +34,7 @@ const graphs = {
       graphData.getGraphAndLinks(onSuccess, onError);
     })
 
-    router.get('/flowchart', function (req, res) {
+    router.get('/:formname/flowchart', function (req, res) {
       let onSuccess = function (data) {
         let graph = data.graph;
         let links = data.links;

--- a/editor/app/views/flowchart.html
+++ b/editor/app/views/flowchart.html
@@ -1,7 +1,7 @@
   {% extends "layout.html" %}
 
   {% block page_title %}
-    FLowchart - Forms editor
+    Flowchart - Forms editor
   {% endblock %}
 
   {% block content %}

--- a/editor/app/views/macros/fields.ntk
+++ b/editor/app/views/macros/fields.ntk
@@ -1,0 +1,60 @@
+{% macro generic(fieldobj, fieldindex, multiplefields) %}
+
+  {% for prop in ['label', 'legend', 'hint'] %}
+
+	  {% if fieldobj[prop] %}
+		{{ frontend.govukInput({
+		  "label": {
+			"text": "Field " + fieldindex + " " + prop
+		  },
+		  "name": fieldobj.id + "." + prop,
+		  "id": fieldobj.id + "." + prop,
+		  "value": fieldobj[prop]
+		}) }}
+	  {% endif %}
+
+  {% endfor %} {# end loop through field props #}
+
+  {% if fieldobj.items %}
+
+    {% set multipleitems = fieldobj.items | length > 1 %}
+
+    {% if multipleitems %}
+    <fieldset>
+    <legend class="visuallyhidden">
+      Field {{ fieldindex }}, options
+    </legend>
+    {% endif %}
+
+    {% for item in fieldobj.items %}
+
+      {% set itemindex = loop.index %}
+
+      <div class="grid-row">
+      {% for prop in ['label', 'value'] %}
+
+        <div class="column-one-half">
+        {% if item[prop] %}
+        {{ frontend.govukInput({
+          "label": {
+          "text": "Option " + itemindex + " " + prop
+          },
+          "name": item.id + "." + prop,
+          "id": item.id + "." + prop,
+          "value": item[prop]
+        }) }}
+        {% endif %}
+        </div>
+
+      {% endfor %} {# end loop through item props #}
+      </div>
+
+    {% endfor %} {# end of loop through items #}
+
+    {% if multipleitems %}
+    </fieldset>
+    {% endif %}
+
+  {% endif %} {# end if field has items #}
+
+{% endmacro %}

--- a/editor/app/views/page.html
+++ b/editor/app/views/page.html
@@ -12,7 +12,7 @@
   <div class="grid-row">
     <div class="column-one-half" id="editor-wrapper">
     {{ frontend.govukBackLink({
-      "href": "/forms/" + formname,
+      "href": "/forms/" + form.name,
       "text": "Back to pages in this form"
     }) }}
 
@@ -55,46 +55,50 @@
           </legend>
           {% endif %}
 
-            {{ fields.generic(field, fieldrefs, fieldindex, multiplefields) }}
+            {{ fields.generic(field, fieldindex, multiplefields) }}
 
           {% if multiplefields %}
           </fieldset>
           {% endif %}
         {% endfor %}
 
-        {% if page.next | length > 1 %}
+        {% if page.next %}
+
+        {% set multiplenext = page.next | length > 1 %}
+
+        {% if multiplenext %}
         <fieldset>
-          <legend class="heading-small">
-            Next pages
+          <legend>
+            <h2 class="heading-medium">Next pages</h2>
           </legend>
-          {% for option in page.next %}
+        {% else %}
+          <h2 class="heading-medium">Next pages</h2>
+        {% endif %}
 
-          <fieldset>
-            <legend>
-              Option {{ loop.index }}
-            </legend>
-            
-            {% for prop, txt in {
-              'page': 'Slug',
-              'if': 'Condition'
-            } %}
+        {% for option in page.next %}
+          
+          <div class="grid-row">
+          {% for prop, txt in {
+            'page': 'Slug',
+            'if': 'Condition'
+          } %}
 
-						{{ frontend.govukInput({
-							"label": {
-								"text": txt
-							},
-							"name": option.id + "." + prop,
-							"id": option.id + "." + prop,
-							"value": page.next[loop.index0][prop]
-						}) }}
+          <div class="column-one-half">
+          {{ frontend.govukInput({
+            "label": {
+              "text": txt
+            },
+            "name": option.id + "." + prop,
+            "id": option.id + "." + prop,
+            "value": page.next[loop.index0][prop]
+          }) }}
+          </div>
 
-            {% endfor %}
+          {% endfor %}
+          </div>
 
-          </fieldset>
+        {% endfor %} {# end of loop through next pages #}
 
-          {% endfor %} {# end of loop through next pages #}
-
-         </fieldset>
         {% else %}
 
           {{ frontend.govukInput({
@@ -105,6 +109,38 @@
             "id": page.next[0].id + ".page",
             "value": page.next[0].page
           }) }}
+
+        {% endif %}
+
+        {% if mutiplenext %}
+        </fieldset>
+        {% endif %}
+
+        {% set fieldrefs = page.uniqueFieldrefs %}
+
+        {% if fieldrefs %}
+
+          {% set multiplefields = fieldrefs | length > 1 %}
+
+          {% if multiplefields %}
+          <fieldset>
+            <legend>
+              <h2 class="heading-medium">Optional fields</h2>
+            </legend>
+          </fieldset>
+          {% else %}
+          <h2 class="heading-medium">Optional fields</h2>
+          {% endif %}
+
+          {% for fieldref in fieldrefs %}
+
+            {{ fields.generic(form.fields[fieldref], loop.index, multiplefields) }}
+            
+          {% endfor %}
+
+          {% if multiplefields %}
+          </fieldset>
+          {% endif %}
 
         {% endif %}
 

--- a/editor/app/views/page.html
+++ b/editor/app/views/page.html
@@ -1,5 +1,6 @@
 {% extends "layout.html" %}
 {% import "frontend_macros.ntk" as frontend with context %}
+{% import "macros/fields.ntk" as fields with context %}
 
 {% block page_title %}
   {{ page.heading }} - Forms editor
@@ -23,130 +24,43 @@
           <input class="form-control form-control-2-3" id="{{ page.id }}.heading" name="{{ page.id }}.heading" value="{{ page.heading}}">
         </div>
 
-        {% if page.pagetype %}
-          {{ frontend.govukInput({
-            "label": {
-              "text": "Page type"
-            },
-            "name": page.id + ".pagetype",
-            "id": page.id + ".pagetype",
-            "value": page.pagetype
-          }) }}
-        {% endif %}
+        {% for prop, txt in {
+            'pagetype': 'Page type',
+            'guidance': 'Page guidance',
+            'detail': 'Page detail'
+        } %}
 
-        {% if page.guidance %}
-          {{ frontend.govukTextarea({
-            "label": {
-              "text": "Guidance"
-            },
-            "name": page.id+ ".guidance",
-            "id": page.id+ ".guidance",
-            "value": page.guidance
-          }) }}
-        {% endif %}
+          {% if page[prop] %}
+            {{ frontend.govukInput({
+              "label": {
+                "text": txt
+              },
+              "name": page.id + "." + prop,
+              "id": page.id + "." + prop,
+              "value": page[prop]
+            }) }}
+          {% endif %}
 
-        {% if page.detail %}
-          {{ frontend.govukInput({
-            "label": {
-              "text": "Detail"
-            },
-            "name": page.id + ".detail",
-            "id": page.id + ".detail",
-            "value": page.detail
-          }) }}
-        {% endif %}
+        {% endfor %} {# end loop through page props #}
 
         {% for field in page.fields %}
 
           {% set fieldindex = loop.index %}
+          {% set multiplefields = page.fields | length > 1 %}
 
-          {# Wrap in a fieldset if multiple properties #}
-          {% if page.fields | length > 1 %}
+          {% if multiplefields %}
           <fieldset>
-            <legend class="visuallyhidden">
-              Field {{ fieldindex }}
-            </legend>
+          <legend class="visuallyhidden">
+            Field {{ fieldindex }}
+          </legend>
           {% endif %}
 
-          {% if field.label %}
-            {{ frontend.govukInput({
-              "label": {
-                "text": "Field 1, label " + fieldindex
-              },
-              "name": field.id + ".label",
-              "id": field.id + ".label",
-              "value": field.label
-            }) }}
-          {% elif field.legend %}
-            {{ frontend.govukInput({
-              "label": {
-                "text": "Field 1, legend " + fieldindex
-              },
-              "name": field.id + ".legend",
-              "id": field.id + ".legend",
-              "value": field.legend
-            }) }}
-          {% endif %}
+            {{ fields.generic(field, fieldrefs, fieldindex, multiplefields) }}
 
-          {% if field.hint %}
-            {{ frontend.govukInput({
-              "label": {
-                "text": "Field 1 " + fieldindex + " hint"
-              },
-              "name": field.id + ".hint",
-              "id": field.id + ".hint",
-              "value": field.hint
-            }) }}
-          {% endif %}
-
-          {% if field.items %}
-            {% for item in field.items %}
-              {% set optionindex = loop.index %}
-
-              {# Wrap in a fieldset if multiple properties #}
-              {% if field.items | length > 1 %}
-              <fieldset>
-                <legend class="visuallyhidden">
-                  Field {{ fieldindex }}, option {{ optionindex }}
-                </legend>
-              {% endif %}
-
-              {% if item.label %}
-                {{ frontend.govukInput({
-                  "label": {
-                    "text": "Option " + optionindex + " label" 
-                  },
-                  "name": item.id + ".label",
-                  "id": item.id + ".label",
-                  "value": item.label
-                }) }}
-              {% endif %}
-
-              {% if item.hint %}
-                {{ frontend.govukInput({
-                  "label": {
-                    "text": "Option 1 " + optionindex + " Hint" 
-                  },
-                  "name": item.id + ".hint",
-                  "id": item.id + ".hint",
-                  "value": item.hint
-                }) }}
-              {% endif %}
-
-            {% endfor %} {# end of loop through items #}
-
-            {% if field.items | length > 1 %}
-            </fieldset>
-            {% endif %}
-
-          {% endif %}
-
-          {# Wrap in a fieldset if multiple properties #}
-          {% if page.fields | length > 1 %}
+          {% if multiplefields %}
           </fieldset>
           {% endif %}
-
-        {% endfor %} {# end of loop through fields #}
+        {% endfor %}
 
         {% if page.next | length > 1 %}
         <fieldset>
@@ -160,26 +74,25 @@
               Option {{ loop.index }}
             </legend>
             
-						{{ frontend.govukInput({
-							"label": {
-								"text": "Slug"
-							},
-							"name": option.id + ".page",
-							"id": option.id + ".page",
-							"value": page.next[loop.index0].page
-						}) }}
+            {% for prop, txt in {
+              'page': 'Slug',
+              'if': 'Condition'
+            } %}
 
 						{{ frontend.govukInput({
 							"label": {
-								"text": "Condition"
+								"text": txt
 							},
-							"name": option.id + ".if",
-							"id": option.id + ".if",
-							"value": page.next[loop.index0].if
+							"name": option.id + "." + prop,
+							"id": option.id + "." + prop,
+							"value": page.next[loop.index0][prop]
 						}) }}
+
+            {% endfor %}
+
           </fieldset>
 
-          {% endfor %} {# end of loop through next page options #}
+          {% endfor %} {# end of loop through next pages #}
 
          </fieldset>
         {% else %}

--- a/editor/app/views/page.html
+++ b/editor/app/views/page.html
@@ -61,7 +61,7 @@
           {% set fieldindex = loop.index %}
 
           {# Wrap in a fieldset if multiple properties #}
-          {% if field.hint %}
+          {% if page.fields | length > 1 %}
           <fieldset>
             <legend class="visuallyhidden">
               Field {{ fieldindex }}
@@ -104,7 +104,7 @@
               {% set optionindex = loop.index %}
 
               {# Wrap in a fieldset if multiple properties #}
-              {% if item.hint %}
+              {% if field.items | length > 1 %}
               <fieldset>
                 <legend class="visuallyhidden">
                   Field {{ fieldindex }}, option {{ optionindex }}
@@ -135,14 +135,14 @@
 
             {% endfor %} {# end of loop through items #}
 
-            {% if item.hint %}
+            {% if field.items | length > 1 %}
             </fieldset>
             {% endif %}
 
           {% endif %}
 
           {# Wrap in a fieldset if multiple properties #}
-          {% if field.hint %}
+          {% if page.fields | length > 1 %}
           </fieldset>
           {% endif %}
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -181,7 +181,37 @@ function makeFieldrefsUnique(pageFieldrefLogs, form) {
   addNewFields(formFieldrefLog);
 };
 
+
+function pruneFieldrefs(page, pageName, form) {
+  let log = logFieldrefs(page, pageName, form); 
+  let fieldrefs = page.fieldrefs;
+  let uniquerefs = fieldrefs.slice();
+
+  fieldrefs.forEach(fieldName => {
+    let fieldReferenced = false;
+    let duplicates = [];
+    let referers;
+    
+    if (fieldName in log) {
+      referers = log[fieldName];
+
+      duplicates = referers.filter(referer => { return fieldrefs.includes(referer); });
+
+      // field is referenced by another in fieldrefs so remove
+      duplicates.forEach(duplicate => {
+        if (uniquerefs.includes(duplicate)) {
+          uniquerefs.splice(uniquerefs.indexOf(duplicate), 1);
+        }
+      });
+    }
+  });
+
+  return uniquerefs;
+};
+
+
 module.exports = {
 	'logFieldrefs': logFieldrefs,
-	'makeFieldrefsUnique': makeFieldrefsUnique
+	'makeFieldrefsUnique': makeFieldrefsUnique,
+  'pruneFieldrefs': pruneFieldrefs
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,187 @@
+function logFieldrefs(page, pageName, form) {
+  var log = {};
+  var checkFields;
+  var checkField;
+  var checkFieldRefs;
+  var addToLog;
+
+  addToLog = function(fieldName, parentName) {
+    if (fieldName in log) {
+      log[fieldName].push(parentName);
+    }
+  };
+
+  checkField = function(field, fieldName) {
+    if ('fields' in field) {
+      checkFields(field.fields, fieldName);
+    }
+    if ('items' in field) {
+      checkFieldItems(field.items, fieldName);
+    }
+  };
+
+  checkFields = function(fields, parentName) {
+    fields.forEach(fieldName => {
+      var field = form.fields[fieldName];
+
+      addToLog(fieldName, parentName);
+
+      checkField(field, fieldName);
+    });
+  };
+
+  checkFieldItems = function(items, fieldName) {
+    items.forEach((item, idx) => {
+      var fieldref, referencedField;
+
+      if ('fieldref' in item) {
+
+        fieldref = item.fieldref
+        referencedField = form.fields[fieldref];
+
+        addToLog(fieldref, fieldName);
+
+        if ('fields' in referencedField) {
+          checkFields(referencedField.fields, fieldref);
+        }
+      }
+      
+    });
+  };
+
+  // create a log entry for each fieldref
+  page.fieldrefs.forEach(fieldref => {
+    log[fieldref] = [];
+  });
+
+  // check the page fields, and all their descendent fields.
+  // log every use of a referenced field against the fieldset it is in.
+  page.fields.forEach(name => {
+    checkField(form.fields[name], name);
+  });
+
+  return log;
+};
+
+
+function makeFieldrefsUnique(pageFieldrefLogs, form) {
+  let formFieldrefLog = {};
+  let updateFields;
+  let updateItems;
+  let updateFieldrefs;
+  let getNewName;
+  let addRefererToFormLog;
+  let addNewFields;
+
+  updateFields = function(oldref, newref, fields) {
+    fields.splice(fields.indexOf(oldref), 1, newref);
+  };
+
+
+  updateItems = function(oldref, newref, items) {
+    items.forEach(item => {
+      if (items.fieldref === oldref) {
+        items.fieldref = newref;
+      }
+    });
+  };
+
+
+  getNewName = function(fieldName, refererName) {
+    return refererName + (fieldName[0].toUpperCase() + fieldName.substring(1));
+  };
+
+
+  updateFieldrefs = function(fieldName, referers, fieldrefs) {
+    let oldrefs = [];
+
+    referers.forEach(refererName => {
+      let newName = getNewName(fieldName, refererName);
+
+      // add new name to page.fieldrefs
+      if ('fields' in form.fields[fieldName]) {
+        fieldrefs.push(newName);
+      }
+      else { // fields need to be declared before fieldsets so go at the front
+        fieldrefs.unshift(newName);
+      }
+
+      // store old ref for later deletion
+      if (oldrefs.indexOf(fieldName) === -1) { oldrefs.push(fieldName); }
+    });
+
+    oldrefs.forEach(oldref => {
+      // remove original name from fieldrefs
+      fieldrefs.splice(fieldrefs.indexOf(oldref), 1);
+    });
+
+    return fieldrefs;
+  };
+
+
+  addReferersToFormLog = function(fieldref, referers) {
+    if (!(fieldref in formFieldrefLog)) {
+      formFieldrefLog[fieldref] = referers;
+    }
+    else {
+      referers.forEach(referer => {
+        if (formFieldrefLog[fieldref].indexOf(referer) === -1) {
+          formFieldrefLog[fieldref].push(referer);
+        }
+      });
+    }
+  };
+
+
+  addNewFields = function(formFieldrefLog) {
+    for (fieldName in formFieldrefLog) {
+      let referers = formFieldrefLog[fieldName];
+      
+      referers.forEach(referer => {
+        // make new field for that name
+        let newName = getNewName(fieldName, referer);
+        let newField = Object.assign({}, form.fields[fieldName]);
+
+        newField.field = newName;
+        form.fields[newName] = newField;
+
+        // update all existing references to the field in referer
+        let refererField = form.fields[referer];
+
+        if ('fields' in refererField) {
+          updateFields(fieldName, newName, refererField.fields);
+        }
+        if ('items' in refererField) {
+          updateItems(fieldName, newName, refererField.items);
+        }
+      });
+    }
+  };
+
+
+  // update the fieldrefs for each page
+  for (let pageName in pageFieldrefLogs) {
+    let pageFieldrefLog = pageFieldrefLogs[pageName];
+    let page = form.pages[pageName];
+
+    for (let fieldref in pageFieldrefLog) {
+      let referers = pageFieldrefLog[fieldref];
+
+      if (referers.length > 1) {
+        page.fieldrefs = updateFieldrefs(fieldref, referers, page.fieldrefs);
+
+        // add any new referers to formFieldrefLog
+        addReferersToFormLog(fieldref, referers);
+      }
+    }
+
+  }
+
+  // add any fields now referenced and update their references
+  addNewFields(formFieldrefLog);
+};
+
+module.exports = {
+	'logFieldrefs': logFieldrefs,
+	'makeFieldrefsUnique': makeFieldrefsUnique
+};

--- a/templates/submit_macros.ntk
+++ b/templates/submit_macros.ntk
@@ -183,10 +183,13 @@
     "id": {{ text_param(field.field) }}
 {{ frontend_endmacro() }}
 
-{%- elif field.inputtype == 'fieldset' -%}
-    {% for fieldref in field.fields %}
+{%- elif field.inputtype == 'fieldset' %}
+  <fieldset>
+    <legend class="visuallyhidden">{{ field.legend }}</legend>
+    {%- for fieldref in field.fields %}
   {%raw%}{{{%endraw%}{{ fieldref }}Ref{%raw%} | safe}}{%endraw%}
     {%- endfor %}
+  </fieldset>
 
 {%- elif field.inputtype == 'list' -%}
     {% for fieldref in field.fields %}


### PR DESCRIPTION
The only thing left out of the editor's page view because it lets users edit fields that appear multiple times in the same page.

This also fixes an issue with the runner where this resulted in pages containing several fields with the same id/name attribute.

The fix creates new fields for each instance with (id/name)s rewritten to reference the containing field/fieldset. For example, a `serviceNumber` field for users who served in the army (and therefore selected that service) would be renamed `ArmyServiceNumber`.