### PR TITLE
Add schemas

### DIFF
--- a/bin/validate.py
+++ b/bin/validate.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import json
+import argparse
+import jsonschema
+
+def validate(datafile, schemafile):
+    data = json.load(open(datafile))
+    schema = json.load(open(schemafile))
+
+    jsonschema.validate(data, schema)
+
+parser = argparse.ArgumentParser(description='Validate the JSON for a form.')
+parser.add_argument('datafile', metavar='F', help='JSON file to validate')
+parser.add_argument('schemafile', metavar='S', help='Schema file to validate against')
+
+args = parser.parse_args()
+datafile = args.datafile
+schemafile = args.schemafile
+
+if (not os.path.isfile(datafile)):
+    print("{} does not exist".format(datafile), file=sys.stderr)
+    exit(1)
+
+if (not os.path.isfile(schemafile)):
+    print("{} does not exist".format(schemafile), file=sys.stderr)
+    exit(1)
+
+validate(datafile, schemafile)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+jsonschema==2.6.0

--- a/schemas/fields/checkboxes.json
+++ b/schemas/fields/checkboxes.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "id": "uk.gov.gaap.submit.editor.fields.checkboxes",
+  "type": "object",
+  "properties": {
+    "inputtype": {
+      "type": "string",
+      "enum": ["checkboxes"]
+    },
+    "items": {
+      "type": "array",
+      "items": {
+        "properties": {
+          "label": { "type": "string" },
+          "value": { "type": "string" },
+          "hint": { "type": "string" },
+          "fieldref": { "type": "string" }
+        },
+        "required": ["label", "value"]
+      }
+    },
+    "legend": { "type": "string" },
+    "hint": { "type": "string" }
+  },
+  "required": ["inputtype", "items"]
+}

--- a/schemas/fields/fieldset.json
+++ b/schemas/fields/fieldset.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "id": "uk.gov.gaap.submit.editor.fields.fieldset",
+  "type": "object",
+  "properties": {
+    "inputtype": {
+      "type": "string",
+      "enum": ["fieldset"]
+    },
+    "legend": { "type": "string" },
+    "fields": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "required": ["inputtype", "legend", "fields"]
+}

--- a/schemas/fields/image.json
+++ b/schemas/fields/image.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "id": "uk.gov.gaap.submit.editor.fields.image",
+  "type": "object",
+  "properties": {
+    "inputtype": {
+      "type": "string",
+      "enum": ["image"]
+    },
+    "label": { "type": "string" }
+  },
+  "required": ["inputtype", "label"]
+}

--- a/schemas/fields/list.json
+++ b/schemas/fields/list.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "id": "uk.gov.gaap.submit.editor.fields.list",
+  "type": "object",
+  "properties": {
+    "inputtype": {
+      "type": "string",
+      "enum": ["list"]
+    },
+    "label": { "type": "string" },
+    "description": {
+      "type": "string"
+    },
+    "field": { "type": "string" },
+    "min-length": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "max-length": {
+      "type": "integer",
+      "minimum": 0
+    }
+  },
+  "required": ["inputtype", "label", "description", "field", "min-length", "max-length"]
+}

--- a/schemas/fields/radio.json
+++ b/schemas/fields/radio.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "id": "uk.gov.gaap.submit.editor.fields.radio",
+  "type": "object",
+  "properties": {
+    "inputtype": {
+      "type": "string",
+      "enum": ["radio"]
+    },
+    "items": {
+      "type": "array",
+      "items": {
+        "properties": {
+          "label": { "type": "string" },
+          "value": { "type": "string" },
+          "fieldref": { "type": "string" }
+        },
+        "required": ["label", "value"]
+      }
+    },
+    "legend": { "type": "string" },
+    "hint": { "type": "string" }
+  },
+  "required": ["inputtype", "items"]
+}

--- a/schemas/fields/text.json
+++ b/schemas/fields/text.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "id": "uk.gov.gaap.submit.editor.fields.text",
+  "type": "object",
+  "properties": {
+    "inputtype": {
+      "type": "string",
+      "enum": ["text"]
+    },
+    "label": { "type": "string" },
+    "hint": { "type": "string" },
+    "datatype": {
+      "type": "string",
+      "enum": ["date", "text"]
+    },
+    "description": {
+      "type": "string"
+    }
+  },
+  "required": ["inputtype", "label"]
+}

--- a/schemas/fields/textarea.json
+++ b/schemas/fields/textarea.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "id": "uk.gov.gaap.submit.editor.fields.textarea",
+  "type": "object",
+  "properties": {
+    "inputtype": {
+      "type": "string",
+      "enum": ["textarea"]
+    },
+    "label": { "type": "string" }
+  },
+  "required": ["inputtype", "label"]
+}

--- a/schemas/form.json
+++ b/schemas/form.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "id": "uk.gov.gaap.submit.editor.form",
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "heading": { "type": "string" },
+    "phase": {
+      "type": "string",
+      "enum": ["alpha", "beta", "live"]
+    },
+    "organisations": {
+      "type": "array",
+      "items": { "$ref": "file:schemas/organisations.json" },
+      "minItems": 0
+    },
+    "pages": {
+      "type": "object",
+      "patternProperties": {
+        "^.+$": {
+          "anyOf": [
+            { "$ref": "file:schemas/pages/start-page.json" },
+            { "$ref": "file:schemas/pages/question.json" },
+            { "$ref": "file:schemas/pages/check-your-answers.json" },
+            { "$ref": "file:schemas/pages/bounce.json" },
+            { "$ref": "file:schemas/pages/application-complete.json"}
+          ]
+        }
+      }
+    },
+    "fields": {
+      "type": "object",
+      "patternProperties": {
+        "^.+$": {
+          "anyOf": [
+            { "$ref": "file:schemas/fields/checkboxes.json" },
+            { "$ref": "file:schemas/fields/fieldset.json" },
+            { "$ref": "file:schemas/fields/image.json" },
+            { "$ref": "file:schemas/fields/list.json" },
+            { "$ref": "file:schemas/fields/radio.json" },
+            { "$ref": "file:schemas/fields/text.json" },
+            { "$ref": "file:schemas/fields/textarea.json" }
+          ]
+        }
+      }
+    }
+  },
+  "required": ["name", "heading", "phase", "organisations", "pages", "fields"]
+}

--- a/schemas/organisations.json
+++ b/schemas/organisations.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "id": "uk.gov.gaap.submit.editor.organisations",
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "organisation": { "type": "string" },
+    "website": { "type": "string" }
+  },
+  "required": ["name", "organisation", "website"]
+}

--- a/schemas/pages/application-complete.json
+++ b/schemas/pages/application-complete.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "id": "uk.gov.gaap.submit.editor.page.application-complete",
+  "type": "object",
+  "properties": {
+    "pagetype": {
+      "type": "string",
+      "enum": ["application-complete"]
+    },
+    "heading": {
+      "type": "string"
+    },
+    "guidance": {
+      "type": "string"
+    },
+    "detail": {
+      "type": "string"
+    }
+  },
+  "required": ["pagetype", "heading", "guidance", "detail"]
+}

--- a/schemas/pages/bounce.json
+++ b/schemas/pages/bounce.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "id": "uk.gov.gaap.submit.editor.page.bounce",
+  "type": "object",
+  "properties": {
+    "pagetype": {
+      "type": "string",
+      "enum": ["bounce"]
+    },
+    "heading": {
+      "type": "string"
+    },
+    "guidance": {
+      "type": "string"
+    }
+  },
+  "required": ["pagetype", "heading", "guidance"]
+}

--- a/schemas/pages/check-your-answers.json
+++ b/schemas/pages/check-your-answers.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "id": "uk.gov.gaap.submit.editor.page.check-your-answers",
+  "type": "object",
+  "properties": {
+    "pagetype": {
+      "type": "string",
+      "enum": ["check-your-answers"]
+    },
+    "heading": {
+      "type": "string"
+    },
+    "next": {
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "page": { "type": "string" },
+              "if": { "type": "string" }
+            },
+            "required": ["page"]
+          }
+        }
+      ]
+    }
+  },
+  "required": ["pagetype", "heading", "next"]
+}

--- a/schemas/pages/question.json
+++ b/schemas/pages/question.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "id": "uk.gov.gaap.submit.editor.page.question",
+  "type": "object",
+  "properties": {
+    "pagetype": {
+      "type": "string",
+      "enum": ["question"]
+    },
+    "heading": {
+      "type": "string"
+    },
+    "guidance": {
+      "type": "string"
+    },
+    "detail": {
+      "type": "string"
+    },
+    "fields": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "fieldrefs": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "next": {
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "page": { "type": "string" },
+              "if": { "type": "string" }
+            },
+            "required": ["page"]
+          }
+        }
+      ]
+    }
+  },
+  "required": ["pagetype", "heading", "fields", "next"]
+}

--- a/schemas/pages/start-page.json
+++ b/schemas/pages/start-page.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "id": "uk.gov.gaap.submit.editor.page.start-page",
+  "type": "object",
+  "properties": {
+    "pagetype": {
+      "type": "string",
+      "enum": ["start-page"]
+    },
+    "heading": {
+      "type": "string"
+    },
+    "guidance": {
+      "type": "string"
+    },
+    "detail": {
+      "type": "string"
+    },
+    "next": {
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "page": { "type": "string" },
+              "if": { "type": "string" }
+            },
+            "required": ["page"]
+          }
+        }
+      ]
+    }
+  },
+  "required": ["pagetype", "heading", "guidance", "next"]
+}


### PR DESCRIPTION
Splits schemas out into forms, pages and fields.

I tested with them all in one file but it had no real effect on the quality of the error messages so leaving as is for now.