### PR TITLE
Fix iframe URLs

### DIFF
--- a/editor/app/views/form.html
+++ b/editor/app/views/form.html
@@ -60,7 +60,7 @@
     </div>
     <div class="column-one-half">
       <div id="prototype-wrapper" class="prototype-wrapper">
-        <iframe name="prototype" id="prototype" class="prototype" src="http://localhost:3000/{{ currentFormPage }}/" height="800px" /></iframe>
+        <iframe name="prototype" id="prototype" class="prototype" src="http://localhost:3000/{{ currentFormPage }}" height="800px" /></iframe>
       </div>
     </div>
   </div>

--- a/editor/app/views/index.html
+++ b/editor/app/views/index.html
@@ -23,7 +23,7 @@
       </div>
       <div class="column-one-half">
         <div id="prototype-wrapper" class="prototype-wrapper">
-          <iframe name="prototype" id="prototype" class="prototype" src="http://localhost:3000/{{ currentFormPage }}/" height="800px" /></iframe>
+          <iframe name="prototype" id="prototype" class="prototype" src="http://localhost:3000/{{ currentFormPage }}" height="800px" /></iframe>
         </div>
       </div>
     </div>

--- a/editor/app/views/page.html
+++ b/editor/app/views/page.html
@@ -149,7 +149,7 @@
     </div>
     <div class="column-one-half">
       <div id="prototype-wrapper" class="prototype-wrapper">
-        <iframe name="prototype" id="prototype" class="prototype" src="http://localhost:3000/{{ currentFormPage }}/" height="800px"></iframe>
+        <iframe name="prototype" id="prototype" class="prototype" src="http://localhost:3000/{{ currentFormPage }}" height="800px"></iframe>
       </div>
     </div>
   </div>


### PR DESCRIPTION
The trailing slash breaks the prototype's routing
pattern-matching.